### PR TITLE
Set the base exception message to something useful

### DIFF
--- a/ClientLibrary/FaceAPIException.cs
+++ b/ClientLibrary/FaceAPIException.cs
@@ -57,6 +57,7 @@ namespace Microsoft.ProjectOxford.Face
         /// <param name="errorMessage">Message represents the detailed error description</param>
         /// <param name="statusCode">Http status code</param>
         public FaceAPIException(string errorCode, string errorMessage, HttpStatusCode statusCode)
+            : base(errorMessage + "(" + errorCode + ")")
         {
             ErrorCode = errorCode;
             ErrorMessage = errorMessage;


### PR DESCRIPTION
Any error logger will look at either the `Message` field or use `ToString()` when logging an exception.
As we do not set `Message`, there will be no useful information in that log message when logging a FaceAPIException.
You instead get:
`Microsoft.ProjectOxford.Face.FaceAPIException: Exception of type 'Microsoft.ProjectOxford.Face.FaceAPIException' was thrown.`

Now we set base.Message (via the constructor) so that we get useful error logs :)

Fixes https://github.com/Microsoft/Cognitive-Face-DotNetCore/issues/3 (once this targets standard and obsoletes that repo too...)